### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.interactive-presentation-backend
+++ b/Dockerfile.interactive-presentation-backend
@@ -1,0 +1,20 @@
+FROM golang:1.21.0 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /interactive-presentation-backend
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /
+COPY --from=builder /interactive-presentation-backend /interactive-presentation-backend
+COPY db/migration /db/migration
+
+EXPOSE 8080
+
+CMD ["/interactive-presentation-backend"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO interactive-presentation
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,79 @@
+namespace: interactive-presentation
+
+postgres-database:
+  defines: runnable
+  inherits: postgresql/db
+  metadata:
+    name: postgres-database
+    description: External PostgreSQL database required by the backend service.
+    icon: https://www.postgresql.org/media/img/about/press/elephant.png
+  variables:
+    db_name:
+      type: string
+      value: monk
+      description: ''
+    db_pass:
+      type: string
+      value: adminpassword
+      description: ''
+    db_user:
+      type: string
+      value: monk
+      description: ''
+
+interactive-presentation-backend:
+  defines: runnable
+  metadata:
+    name: interactive-presentation-backend
+    description: Backend service for handling HTTP requests and database operations.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    interactive-presentation-backend:
+      image: env-4349.registry.local/interactive-presentation-backend:main-c397d2e
+      build: .
+      dockerfile: Dockerfile.interactive-presentation-backend
+  services:
+    http-server:
+      description: Port for handling HTTP requests
+      container: interactive-presentation-backend
+      port: 8080
+      host-port: 8080
+      publish: true
+      protocol: tcp
+  connections:
+    database-connection:
+      target: interactive-presentation/postgres-database
+      service: postgres
+      optional: true
+      description: Connection to the PostgreSQL database service.
+  variables:
+    environment:
+      env: ENVIRONMENT
+      type: string
+      value: production
+      description: >-
+        The environment where the application is running, e.g., development,
+        staging, production.
+    db-driver:
+      env: DB_DRIVER
+      type: string
+      value: postgres
+      description: The database driver to use for database connections.
+    db-source:
+      env: DB_SOURCE
+      type: string
+      value: <- connection-port("database-connection")
+      description: >-
+        The data source name (DSN) specifying the address of the database
+        instance.
+    migration-url:
+      env: MIGRATION_URL
+      type: string
+      value: file://migrations
+      description: The URL or path to the database migration files.
+
+stack:
+  defines: group
+  members:
+    - interactive-presentation/postgres-database
+    - interactive-presentation/interactive-presentation-backend


### PR DESCRIPTION
# Containerization and Deployment Configuration for Interactive-Presentation

This PR introduces containerization and deployment configuration for the Interactive-Presentation application. The application is a backend service written in Go, which connects to a PostgreSQL database and serves HTTP requests.

## Changes Made

- **Dockerfile Creation**: A Dockerfile (`Dockerfile.interactive-presentation-backend`) has been created for the backend service. It sets up the Go environment, installs dependencies, and includes the necessary migration files from the `db/migration` directory.
- **Monk Configuration**: Added `monk.yaml` and `MANIFEST` to define the Monk.io deployment configuration. This includes the setup for the backend service and its connection to a PostgreSQL database.
- **Service Configuration**: Configured the `interactive-presentation-backend` service to read environment variables such as `DB_DRIVER`, `DB_SOURCE`, and `MIGRATION_URL` using the Viper library. The service is set to start on port `8080`.

## Instructions for Continuation

- **Environment Variables**: Ensure that the environment variables `ENVIRONMENT`, `DB_DRIVER`, `DB_SOURCE`, and `MIGRATION_URL` are correctly set in the deployment environment or through a configuration file named `app.env`.
- **Database Connection**: The `database-connection` target port should be set to match the exposed port of the `postgres-database` service, ensuring proper communication between the services.
- **Deployment**: Merge this PR to trigger the deployment process. The application will be re-deployed on each subsequent push, with the backend service connecting to the external PostgreSQL database.

## Summary

The backend service for Interactive-Presentation is now containerized with a corresponding Dockerfile and Monk.io deployment configuration. The service is ready for deployment, with environment variables and database connections configured. Upon merging this PR, the application will be automatically deployed and ready to serve requests.